### PR TITLE
update runtime from nodejs6 to nodejs10.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ This Application using Serverless Application Model (SAM).
 
 ## How To Deploy
 
+### Install node_modules
+
+```bash
+$ cd src
+$ docker run -it -v "$PWD":/var/task lambci/lambda:build-nodejs10.x /bin/bash
+$ npm install
+$ exit
+```
+
 ### A. API Gateway + Lambda Only
 
 ### 1. Package

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ aws cloudformation deploy \
 $ curl \
   -X GET \
   -H 'Accept: image/png' \
-  "https://<your api id>.execute-api.<aws region>.amazonaws.com/<stage>/resize?url=https%3A%2F%2Foctodex.github.com%2Fimages%2Flabtocat.png&width=100&height=100" \
+  "https://<your api id>.execute-api.<aws region>.amazonaws.com/<stage>/resize?url=https%3A%2F%2Foctodex.github.com%2Fimages%2Flabtocat.png&w=100&h=100" \
   > resized-image.png
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,9 +11,9 @@ const createResponse = (statusCode, contentType, body) => {
       'cache-control': 'max-age=31536000'
     },
     isBase64Encoded: true,
-    body: new Buffer(body).toString('base64')
   }
 }
+    body: new Buffer.from(body, 'binary').toString('base64')
 
 const toContentType = (type) => {
   switch(type) {

--- a/template-with-domain.yaml
+++ b/template-with-domain.yaml
@@ -22,7 +22,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Timeout: 180
       CodeUri: ./src
       Events:

--- a/template.yaml
+++ b/template.yaml
@@ -14,7 +14,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Timeout: 180
       CodeUri: ./src
       Events:


### PR DESCRIPTION
nodejs6ランタイムのサポートが終了するので、nodejs10.xランタイムに変更する。